### PR TITLE
Added support to specify the chunk size in Bytes of a time-series on create, add, incrby, and decrby methods. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,3 @@
-# Java Maven CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-java/ for more details
-#
 version: 2.1
 commands:
   early_return_for_forked_pull_requests:
@@ -16,8 +12,45 @@ commands:
               echo "Nothing to do for forked PRs, so marking this step successful"
               circleci step halt
             fi
+
 jobs:
   build:
+    docker:
+      - image: circleci/openjdk:8u171-jdk      
+      - image: redislabs/redistimeseries:latest
+      
+    working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      MAVEN_OPTS: -Xmx3200m
+
+    steps:
+
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "pom.xml" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: mvn dependency:go-offline
+
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "pom.xml" }}
+        
+      - run: mvn pmd:check
+      - run: mvn integration-test 
+
+      - early_return_for_forked_pull_requests
+      
+      - run: bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN}
+
+  nightly_build:
     docker:
       - image: circleci/openjdk:8u171-jdk      
       - image: redislabs/redistimeseries:edge
@@ -46,14 +79,7 @@ jobs:
             - ~/.m2
           key: v1-dependencies-{{ checksum "pom.xml" }}
         
-      # run tests!
-      - run: mvn pmd:check
       - run: mvn integration-test 
-      #- run: mvn cobertura:cobertura          
-
-      - early_return_for_forked_pull_requests
-      
-      - run: bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN}
       
 workflows:
   version: 2
@@ -69,5 +95,5 @@ workflows:
               only:
                 - master
     jobs:
-      - build
+      - nightly_build
 

--- a/src/main/java/com/redislabs/redistimeseries/Command.java
+++ b/src/main/java/com/redislabs/redistimeseries/Command.java
@@ -7,7 +7,9 @@ public enum Command implements ProtocolCommand{
 
     CREATE("TS.CREATE"),
     RANGE("TS.RANGE"),
+    REVRANGE("TS.REVRANGE"),
     MRANGE("TS.MRANGE"),
+    MREVRANGE("TS.MREVRANGE"),
     CREATE_RULE("TS.CREATERULE"),
     DELETE_RULE("TS.DELETERULE"),
     ADD("TS.ADD"),

--- a/src/main/java/com/redislabs/redistimeseries/Range.java
+++ b/src/main/java/com/redislabs/redistimeseries/Range.java
@@ -1,5 +1,10 @@
 package com.redislabs.redistimeseries;
 
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.util.SafeEncoder;
+
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class Range {
@@ -23,5 +28,59 @@ public class Range {
 
   public Value[] getValues() {
     return values;
+  }
+
+  protected static Value[] parseRange(List<Object> range) {
+    Value[] values = new Value[range.size()];
+
+    for(int i=0; i<values.length ; ++i) {
+      @SuppressWarnings("unchecked") List<Object> touple = (List<Object>)range.get(i);
+      values[i] = new Value((Long)touple.get(0), Double.parseDouble(SafeEncoder.encode((byte[])touple.get(1))));
+    }
+    return values;
+  }
+
+  protected static Range[] parseRanges(List<?> result) {
+    Range[] ranges = new Range[result.size()];
+    for(int j=0; j<ranges.length; ++j) {
+      List<?> series = (List<?>)result.get(j);
+      String resKey = SafeEncoder.encode((byte[])series.get(0));
+      List<?> resLabels = (List<?>)series.get(1);
+      Map<String, String> rangeLabels = new HashMap<>();
+      for (Object resLabel : resLabels) {
+        List<byte[]> label = (List<byte[]>) resLabel;
+        rangeLabels.put(SafeEncoder.encode(label.get(0)), SafeEncoder.encode(label.get(1)));
+      }
+      Value[] values = parseRange((List<Object>) series.get(2));
+      ranges[j] = new Range(resKey, rangeLabels, values);
+    }
+    return ranges;
+  }
+
+  protected static byte[][] multiRangeArgs(long from, long to, Aggregation aggregation, long timeBucket, boolean withLabels, int count, String[] filters) {
+    byte[][] args = new byte[3 + (filters==null?0:filters.length) + (aggregation==null?0:3) + (withLabels?1:0) + (count==Integer.MAX_VALUE?0:2)][];
+    int i=0;
+    args[i++] = Protocol.toByteArray(from);
+    args[i++] = Protocol.toByteArray(to);
+    if(aggregation!= null) {
+      args[i++] = Keyword.AGGREGATION.getRaw();
+      args[i++] = aggregation.getRaw();
+      args[i++] = Protocol.toByteArray(timeBucket);
+    }
+    if(withLabels) {
+      args[i++] = Keyword.WITHLABELS.getRaw();
+    }
+    if(count != Integer.MAX_VALUE) {
+      args[i++] = Keyword.COUNT.getRaw();
+      args[i++] = Protocol.toByteArray(count);
+    }
+
+    args[i++] = Keyword.FILTER.getRaw();
+    if(filters != null) {
+      for(String label : filters) {
+        args[i++] = SafeEncoder.encode(label);
+      }
+    }
+    return args;
   }
 }

--- a/src/main/java/com/redislabs/redistimeseries/Range.java
+++ b/src/main/java/com/redislabs/redistimeseries/Range.java
@@ -40,17 +40,22 @@ public class Range {
     return values;
   }
 
+  private static Map<String, String> getLabelsStringStringMap(List<?> resLabels) {
+    Map<String, String> rangeLabels = new HashMap<>(resLabels.size());
+    for (Object resLabel : resLabels) {
+      List<byte[]> label = (List<byte[]>) resLabel;
+      rangeLabels.put(SafeEncoder.encode(label.get(0)), SafeEncoder.encode(label.get(1)));
+    }
+    return rangeLabels;
+  }
+
   protected static Range[] parseRanges(List<?> result) {
     Range[] ranges = new Range[result.size()];
     for(int j=0; j<ranges.length; ++j) {
       List<?> series = (List<?>)result.get(j);
       String resKey = SafeEncoder.encode((byte[])series.get(0));
       List<?> resLabels = (List<?>)series.get(1);
-      Map<String, String> rangeLabels = new HashMap<>();
-      for (Object resLabel : resLabels) {
-        List<byte[]> label = (List<byte[]>) resLabel;
-        rangeLabels.put(SafeEncoder.encode(label.get(0)), SafeEncoder.encode(label.get(1)));
-      }
+      Map<String, String> rangeLabels = getLabelsStringStringMap(resLabels);
       Value[] values = parseRange((List<Object>) series.get(2));
       ranges[j] = new Range(resKey, rangeLabels, values);
     }
@@ -63,12 +68,7 @@ public class Range {
       List<?> series = (List<?>)result.get(j);
       String resKey = SafeEncoder.encode((byte[])series.get(0));
       List<?> resLabels = (List<?>)series.get(1);
-      Map<String, String> rangeLabels = new HashMap<>();
-      for (Object resLabel : resLabels) {
-        List<byte[]> label = (List<byte[]>) resLabel;
-        rangeLabels.put(SafeEncoder.encode(label.get(0)), SafeEncoder.encode(label.get(1)));
-      }
-
+      Map<String, String> rangeLabels = getLabelsStringStringMap(resLabels);
       List<?> tuple = (List<?>)series.get(2);
       Value[] values;
       if(tuple.isEmpty()) {
@@ -101,8 +101,8 @@ public class Range {
       args[i++] = Protocol.toByteArray(count);
     }
 
-    args[i++] = Keyword.FILTER.getRaw();
     if(filters != null) {
+      args[i++] = Keyword.FILTER.getRaw();
       for(String label : filters) {
         args[i++] = SafeEncoder.encode(label);
       }

--- a/src/main/java/com/redislabs/redistimeseries/Range.java
+++ b/src/main/java/com/redislabs/redistimeseries/Range.java
@@ -83,11 +83,19 @@ public class Range {
     return ranges;
   }
 
-  protected static byte[][] multiRangeArgs(long from, long to, Aggregation aggregation, long timeBucket, boolean withLabels, int count, String[] filters) {
-    byte[][] args = new byte[3 + (filters==null?0:filters.length) + (aggregation==null?0:3) + (withLabels?1:0) + (count==Integer.MAX_VALUE?0:2)][];
+  protected static byte[][] multiRangeArgs(Long from, Long to, Aggregation aggregation, long timeBucket, boolean withLabels, Integer count, String[] filters) {
+    byte[][] args = new byte[2 + (filters==null?0:1+filters.length) + (aggregation==null?0:3) + (withLabels?1:0) + (count==null?0:2)][];
     int i=0;
-    args[i++] = Protocol.toByteArray(from);
-    args[i++] = Protocol.toByteArray(to);
+    if(from!=null){
+      args[i++] = Protocol.toByteArray(from);
+    } else {
+      args[i++] = SafeEncoder.encode("-");
+    }
+    if(from!=null){
+      args[i++] = Protocol.toByteArray(to);
+    } else {
+      args[i++] = SafeEncoder.encode("+");
+    }
     if(aggregation!= null) {
       args[i++] = Keyword.AGGREGATION.getRaw();
       args[i++] = aggregation.getRaw();
@@ -96,9 +104,9 @@ public class Range {
     if(withLabels) {
       args[i++] = Keyword.WITHLABELS.getRaw();
     }
-    if(count != Integer.MAX_VALUE) {
+    if(count!=null) {
       args[i++] = Keyword.COUNT.getRaw();
-      args[i++] = Protocol.toByteArray(count);
+      args[i++] = Protocol.toByteArray(count.intValue());
     }
 
     if(filters != null) {

--- a/src/main/java/com/redislabs/redistimeseries/Range.java
+++ b/src/main/java/com/redislabs/redistimeseries/Range.java
@@ -83,19 +83,11 @@ public class Range {
     return ranges;
   }
 
-  protected static byte[][] multiRangeArgs(Long from, Long to, Aggregation aggregation, long timeBucket, boolean withLabels, Integer count, String[] filters) {
+  protected static byte[][] multiRangeArgs(long from, long to, Aggregation aggregation, long timeBucket, boolean withLabels, Integer count, String[] filters) {
     byte[][] args = new byte[2 + (filters==null?0:1+filters.length) + (aggregation==null?0:3) + (withLabels?1:0) + (count==null?0:2)][];
     int i=0;
-    if(from!=null){
-      args[i++] = Protocol.toByteArray(from);
-    } else {
-      args[i++] = SafeEncoder.encode("-");
-    }
-    if(from!=null){
-      args[i++] = Protocol.toByteArray(to);
-    } else {
-      args[i++] = SafeEncoder.encode("+");
-    }
+    args[i++] = Protocol.toByteArray(from);
+    args[i++] = Protocol.toByteArray(to);
     if(aggregation!= null) {
       args[i++] = Keyword.AGGREGATION.getRaw();
       args[i++] = aggregation.getRaw();

--- a/src/main/java/com/redislabs/redistimeseries/Range.java
+++ b/src/main/java/com/redislabs/redistimeseries/Range.java
@@ -34,8 +34,8 @@ public class Range {
     Value[] values = new Value[range.size()];
 
     for(int i=0; i<values.length ; ++i) {
-      @SuppressWarnings("unchecked") List<Object> touple = (List<Object>)range.get(i);
-      values[i] = new Value((Long)touple.get(0), Double.parseDouble(SafeEncoder.encode((byte[])touple.get(1))));
+      @SuppressWarnings("unchecked") List<Object> tuple = (List<Object>)range.get(i);
+      values[i] = Value.parseValue(tuple);
     }
     return values;
   }
@@ -52,6 +52,32 @@ public class Range {
         rangeLabels.put(SafeEncoder.encode(label.get(0)), SafeEncoder.encode(label.get(1)));
       }
       Value[] values = parseRange((List<Object>) series.get(2));
+      ranges[j] = new Range(resKey, rangeLabels, values);
+    }
+    return ranges;
+  }
+
+  protected static Range[] parseMget(List<?> result) {
+    Range[] ranges = new Range[result.size()];
+    for(int j=0; j<ranges.length; ++j) {
+      List<?> series = (List<?>)result.get(j);
+      String resKey = SafeEncoder.encode((byte[])series.get(0));
+      List<?> resLabels = (List<?>)series.get(1);
+      Map<String, String> rangeLabels = new HashMap<>();
+      for (Object resLabel : resLabels) {
+        List<byte[]> label = (List<byte[]>) resLabel;
+        rangeLabels.put(SafeEncoder.encode(label.get(0)), SafeEncoder.encode(label.get(1)));
+      }
+
+      List<?> tuple = (List<?>)series.get(2);
+      Value[] values;
+      if(tuple.isEmpty()) {
+        values = new Value[0];
+      } else {
+        values = new Value[1];
+        values[0] = Value.parseValue((List<Object>) tuple);
+      }
+
       ranges[j] = new Range(resKey, rangeLabels, values);
     }
     return ranges;

--- a/src/main/java/com/redislabs/redistimeseries/RedisTimeSeries.java
+++ b/src/main/java/com/redislabs/redistimeseries/RedisTimeSeries.java
@@ -278,7 +278,6 @@ public class RedisTimeSeries {
    * TS.ADD key * value [RETENTION retentionTime]
    *
    * @param sourceKey
-   * @param timestamp
    * @param value
    * @param retentionTime
    * @return

--- a/src/main/java/com/redislabs/redistimeseries/RedisTimeSeries.java
+++ b/src/main/java/com/redislabs/redistimeseries/RedisTimeSeries.java
@@ -516,7 +516,7 @@ public class RedisTimeSeries {
   /**
    * TS.MRANGE fromTimestamp toTimestamp FILTER filter.
    * </br>
-   * Similar to calling <code>mrange(from, to, null, 0, false, Integer.MAX_VALUE, filters)</code>
+   * Similar to calling <code>mrange(from, to, null, 0, false, null, filters)</code>
    *
    * @param from
    * @param to
@@ -524,13 +524,13 @@ public class RedisTimeSeries {
    * @return
    */
   public Range[] mrange(long from, long to, String... filters) {
-    return mrange(Command.MRANGE,from, to, null /*aggregation*/, 0 /*timeBucket*/, false /*withLabels*/, Integer.MAX_VALUE /*count*/, filters);
+    return multiRange(Command.MRANGE,from, to, null /*aggregation*/, 0 /*timeBucket*/, false /*withLabels*/, null, filters);
   }
 
   /**
    * TS.MRANGE fromTimestamp toTimestamp [COUNT count] FILTER filter.
    * </br>
-   * Similar to calling <code>mrange(from, to, null, 0, false, Integer.MAX_VALUE, filters)</code>
+   * Similar to calling <code>mrange(from, to, null, 0, false, null, filters)</code>
    *
    * @param from
    * @param to
@@ -539,13 +539,13 @@ public class RedisTimeSeries {
    * @return
    */
   public Range[] mrange(long from, long to, int count, String... filters) {
-    return mrange(Command.MRANGE,from, to, null /*aggregation*/, 0 /*timeBucket*/, false /*withLabels*/, count, filters);
+    return multiRange(Command.MRANGE,from, to, null /*aggregation*/, 0 /*timeBucket*/, false /*withLabels*/, count, filters);
   }
 
   /**
    * TS.MRANGE fromTimestamp toTimestamp [AGGREGATION aggregationType timeBucket] FILTER filter.
    * </br>
-   * Similar to calling <code>mrange(from, to, aggregation, retentionTime, false, Integer.MAX_VALUE, filters)</code>
+   * Similar to calling <code>mrange(from, to, aggregation, retentionTime, false, null, filters)</code>
    *
    * @param from
    * @param to
@@ -555,13 +555,13 @@ public class RedisTimeSeries {
    * @return
    */
   public Range[] mrange(long from, long to, Aggregation aggregation, long timeBucket, String... filters) {
-    return mrange(Command.MRANGE, from, to, aggregation, timeBucket, false, Integer.MAX_VALUE /*count*/, filters);
+    return multiRange(Command.MRANGE, from, to, aggregation, timeBucket, false, null, filters);
   }
 
   /**
    * TS.MRANGE fromTimestamp toTimestamp [AGGREGATION aggregationType timeBucket] FILTER filter.
    * </br>
-   * Similar to calling <code>mrange(from, to, aggregation, retentionTime, false, Integer.MAX_VALUE, filters)</code>
+   * Similar to calling <code>mrange(from, to, aggregation, retentionTime, false, null, filters)</code>
    *
    * @param from
    * @param to
@@ -571,13 +571,13 @@ public class RedisTimeSeries {
    * @return
    */
   public Range[] mrange(long from, long to, Aggregation aggregation, long timeBucket, boolean withLabels, String... filters) {
-    return mrange(Command.MRANGE, from, to, aggregation, timeBucket, withLabels, Integer.MAX_VALUE /*count*/, filters);
+    return multiRange(Command.MRANGE, from, to, aggregation, timeBucket, withLabels, null, filters);
   }
 
   /**
    * TS.MRANGE fromTimestamp toTimestamp [COUNT count] [AGGREGATION aggregationType timeBucket] FILTER filter.
    * </br>
-   * Similar to calling <code>mrange(from, to, aggregation, retentionTime, false, Integer.MAX_VALUE, filters)</code>
+   * Similar to calling <code>mrange(from, to, aggregation, retentionTime, false, null, filters)</code>
    *
    * @param from
    * @param to
@@ -588,7 +588,7 @@ public class RedisTimeSeries {
    * @return
    */
   public Range[] mrange(long from, long to, Aggregation aggregation, long timeBucket, boolean withLabels, int count, String... filters) {
-    return mrange(Command.MRANGE, from, to, aggregation, timeBucket, withLabels, count, filters);
+    return multiRange(Command.MRANGE, from, to, aggregation, timeBucket, withLabels, count, filters);
   }
 
   /**
@@ -604,7 +604,7 @@ public class RedisTimeSeries {
    * @param filters
    * @return
    */
-  private Range[] mrange(Command command, long from, long to, Aggregation aggregation, long timeBucket, boolean withLabels, int count, String... filters) {
+  private Range[] multiRange(Command command, long from, long to, Aggregation aggregation, long timeBucket, boolean withLabels, Integer count, String... filters) {
     try (Jedis conn = getConnection()) {
       byte[][] args = Range.multiRangeArgs(from, to, aggregation, timeBucket, withLabels, count, filters);
       List<?> result = sendCommand(conn, command, args).getObjectMultiBulkReply();
@@ -615,7 +615,7 @@ public class RedisTimeSeries {
   /**
    * TS.MREVRANGE fromTimestamp toTimestamp FILTER filter.
    * </br>
-   * Similar to calling <code>mrevrange(from, to, null, 0, false, Integer.MAX_VALUE, filters)</code>
+   * Similar to calling <code>mrevrange(from, to, null, 0, false, null, filters)</code>
    * 
    * @param from
    * @param to
@@ -629,7 +629,7 @@ public class RedisTimeSeries {
   /**
    * TS.MREVRANGE fromTimestamp toTimestamp [COUNT count] FILTER filter.
    * </br>
-   * Similar to calling <code>mrevrange(from, to, null, 0, false, Integer.MAX_VALUE, filters)</code>
+   * Similar to calling <code>mrevrange(from, to, null, 0, false, null, filters)</code>
    * 
    * @param from
    * @param to
@@ -644,7 +644,7 @@ public class RedisTimeSeries {
   /**
    * TS.MREVRANGE fromTimestamp toTimestamp [AGGREGATION aggregationType timeBucket] FILTER filter.
    * </br>
-   * Similar to calling <code>mrevrange(from, to, aggregation, retentionTime, false, Integer.MAX_VALUE, filters)</code>
+   * Similar to calling <code>mrevrange(from, to, aggregation, retentionTime, false, null, filters)</code>
    * 
    * @param from
    * @param to
@@ -660,7 +660,7 @@ public class RedisTimeSeries {
   /**
    * TS.MREVRANGE fromTimestamp toTimestamp [AGGREGATION aggregationType timeBucket] FILTER filter.
    * </br>
-   * Similar to calling <code>mrevrange(from, to, aggregation, retentionTime, false, Integer.MAX_VALUE, filters)</code>
+   * Similar to calling <code>mrevrange(from, to, aggregation, retentionTime, false, null, filters)</code>
    * 
    * @param from
    * @param to
@@ -670,7 +670,7 @@ public class RedisTimeSeries {
    * @return
    */
   public Range[] mrevrange(long from, long to, Aggregation aggregation, long timeBucket, boolean withLabels, String... filters) {
-    return mrevrange(from, to, aggregation, timeBucket, withLabels, Integer.MAX_VALUE /*count*/, filters);
+    return multiRange(Command.MREVRANGE,from, to, aggregation, timeBucket, withLabels, null, filters);
   }
 
   /**
@@ -686,7 +686,7 @@ public class RedisTimeSeries {
    * @return
    */
   public Range[] mrevrange(long from, long to, Aggregation aggregation, long timeBucket, boolean withLabels, int count, String... filters) {
-    return mrange(Command.MREVRANGE, from, to, aggregation, timeBucket, withLabels, count, filters);
+    return multiRange(Command.MREVRANGE, from, to, aggregation, timeBucket, withLabels, count, filters);
   }
   
 

--- a/src/main/java/com/redislabs/redistimeseries/RedisTimeSeries.java
+++ b/src/main/java/com/redislabs/redistimeseries/RedisTimeSeries.java
@@ -704,7 +704,7 @@ public class RedisTimeSeries {
       }
 
       List<?> result = sendCommand(conn, Command.MGET, args).getObjectMultiBulkReply();
-      return Range.parseRanges(result);
+      return Range.parseMget(result);
     }
   }
 

--- a/src/main/java/com/redislabs/redistimeseries/RedisTimeSeries.java
+++ b/src/main/java/com/redislabs/redistimeseries/RedisTimeSeries.java
@@ -1,12 +1,10 @@
 package com.redislabs.redistimeseries;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
 import com.redislabs.redistimeseries.information.Info;
-import com.redislabs.redistimeseries.information.Rule;
 
 import redis.clients.jedis.BinaryClient;
 import redis.clients.jedis.Jedis;
@@ -16,7 +14,9 @@ import redis.clients.jedis.Protocol;
 import redis.clients.jedis.util.Pool;
 import redis.clients.jedis.util.SafeEncoder;
 
-import static com.redislabs.redistimeseries.Range.*;
+import static com.redislabs.redistimeseries.Range.multiRangeArgs;
+import static com.redislabs.redistimeseries.Range.parseRanges;
+
 
 public class RedisTimeSeries {
 

--- a/src/main/java/com/redislabs/redistimeseries/Value.java
+++ b/src/main/java/com/redislabs/redistimeseries/Value.java
@@ -1,5 +1,9 @@
 package com.redislabs.redistimeseries;
 
+import redis.clients.jedis.util.SafeEncoder;
+
+import java.util.List;
+
 public class Value {
 
   private final long time;
@@ -34,5 +38,9 @@ public class Value {
   @Override
   public String toString() {
     return "(" + this.time + ":" + this.val + ")";
+  }
+
+  protected static Value parseValue(List<Object> tuple) {
+    return new Value((Long)tuple.get(0), Double.parseDouble(SafeEncoder.encode((byte[])tuple.get(1))));
   }
 }

--- a/src/main/java/com/redislabs/redistimeseries/information/Info.java
+++ b/src/main/java/com/redislabs/redistimeseries/information/Info.java
@@ -1,5 +1,10 @@
 package com.redislabs.redistimeseries.information;
 
+import com.redislabs.redistimeseries.Aggregation;
+import redis.clients.jedis.util.SafeEncoder;
+
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class Info {
@@ -24,5 +29,34 @@ public class Info {
 
   public Rule getRule(String rule) {
     return rules.get(rule);
+  }
+
+  public static Info parseInfoReply(List<Object> resp) {
+    Map<String, Long> properties = new HashMap<>();
+    Map<String, String> labels = new HashMap<>();
+    Map<String, Rule> rules = new HashMap<>();
+    for(int i=0; i<resp.size() ; i+=2) {
+      String prop = SafeEncoder.encode((byte[])resp.get(i));
+      Object value = resp.get(i+1);
+      if(value instanceof Long) {
+        properties.put(prop, (Long)value);
+      } else {
+        if(prop.equals("labels")) {
+          List<List<byte[]>> labelsList = (List<List<byte[]>>)value;
+          for(List<byte[]> labelBytes : labelsList) {
+            labels.put( SafeEncoder.encode((byte[])labelBytes.get(0)), SafeEncoder.encode((byte[])labelBytes.get(1)));
+          }
+        }
+        else if(prop.equals("rules") ) {
+          List<List<Object>> rulesList = (List<List<Object>>)value;
+          for(List<Object> ruleBytes : rulesList) {
+            String target = SafeEncoder.encode((byte[])ruleBytes.get(0));
+            String agg = SafeEncoder.encode((byte[])ruleBytes.get(2));
+            rules.put( target , new Rule( target, (Long)ruleBytes.get(1), Aggregation.valueOf(agg)));
+          }
+        }
+      }
+    }
+    return new Info(properties, labels, rules);
   }
 }

--- a/src/test/java/com/redislabs/redistimeseries/RedisTimeSeriesTest.java
+++ b/src/test/java/com/redislabs/redistimeseries/RedisTimeSeriesTest.java
@@ -303,43 +303,19 @@ public class RedisTimeSeriesTest {
   }
 
   @Test
-  public void testIncDec() throws InterruptedException {
+  public void testIncrByDecrBy() throws InterruptedException {
     Assert.assertTrue(client.create("seriesIncDec", 100*1000/*100sec retentionTime*/));
-    long startTime = System.currentTimeMillis();
-    Assert.assertEquals(startTime, client.add("seriesIncDec", -1, 1, 10000, null), 0);
-
-    Thread.sleep(1);
-    startTime = System.currentTimeMillis();
-    Assert.assertEquals(startTime, client.incrBy("seriesIncDec", 3, startTime), 0);
-
-    Thread.sleep(1);
-    startTime = System.currentTimeMillis();
-    Assert.assertEquals(startTime, client.decrBy("seriesIncDec", 2, startTime), 0);
-
-    Value[] values = client.range("seriesIncDec", 1L, Long.MAX_VALUE);
+    Assert.assertEquals(1L, client.add("seriesIncDec", 1L, 1, 10000, null), 0);
+    Assert.assertEquals(2L, client.incrBy("seriesIncDec", 3, 2L), 0);
+    Assert.assertEquals(3L, client.decrBy("seriesIncDec", 2, 3L), 0);
+    Value[] values = client.range("seriesIncDec", 1L, 3L);
     Assert.assertEquals(3, values.length);
     Assert.assertEquals(2, values[2].getValue(), 0);
-
-    Thread.sleep(1);
-    startTime = System.currentTimeMillis();
-    Assert.assertEquals(startTime, client.incrBy("seriesIncDec", 3), 0);
-
-    Thread.sleep(1);
-    startTime = System.currentTimeMillis();
-    Assert.assertEquals(startTime, client.decrBy("seriesIncDec", 2), 0);
+    Assert.assertEquals(3L, client.decrBy("seriesIncDec", 2,3L), 0);
     values = client.range("seriesIncDec", 1L, Long.MAX_VALUE);
-    Assert.assertEquals(5, values.length);
-    Assert.assertEquals(3.0, values[4].getValue(), 0);
-    
-    if(moduleVersion>=10400) {
-      Assert.assertEquals(startTime, client.decrBy("seriesIncDec", 2, startTime), 0);
-      values = client.range("seriesIncDec", 1L, Long.MAX_VALUE);
-      Assert.assertEquals(5, values.length);
-      Assert.assertEquals(1, values[4].getValue(), 0);
-    }
-    
+    Assert.assertEquals(3, values.length);
     try {
-      client.incrBy("seriesIncDec", 3, startTime-1);
+      client.incrBy("seriesIncDec", 3, 1L);
       Assert.fail();
     } catch(JedisDataException e) {
       // Error on incrby in the past

--- a/src/test/java/com/redislabs/redistimeseries/RedisTimeSeriesTest.java
+++ b/src/test/java/com/redislabs/redistimeseries/RedisTimeSeriesTest.java
@@ -164,67 +164,67 @@ public class RedisTimeSeriesTest {
     Assert.assertEquals(1, values.length);
     Assert.assertArrayEquals(expectedOverallMaxValues, values);
 
-//    try {
-//      client.mrange(500L, 4600L, Aggregation.COUNT, 1);
-//      Assert.fail();
-//    }catch(JedisDataException e) {}
-//
-//    try {
-//      client.mrange(500L, 4600L, Aggregation.COUNT, 1, (String[])null);
-//      Assert.fail();
-//    }catch(JedisDataException e) {}
-//
-//    Range[] ranges = client.mrange(500L, 4600L, Aggregation.COUNT, 1, "l1=v1");
-//    Assert.assertEquals(1, ranges.length);
-//
-//    Range range = ranges[0];
-//    Assert.assertEquals("seriesAdd", range.getKey());
-//    Assert.assertEquals(new HashMap<>(), range.getLabels());
-//
-//    Value[] rangeValues = range.getValues();
-//    Assert.assertEquals(4, rangeValues.length);
-//    Assert.assertEquals( new Value(1000, 1), rangeValues[0]);
-//    Assert.assertNotEquals( new Value(1000, 1.1), rangeValues[0]);
-//    Assert.assertEquals( 2000L, rangeValues[1].getTime());
-//    Assert.assertEquals( "(2000:1.0)", rangeValues[1].toString());
-//    Assert.assertEquals( 1072695248, rangeValues[1].hashCode());
-//    Assert.assertNotEquals("(2000:1.0)", rangeValues[1]); // verify wrong type
-//
-//    // Add with labels
-//    Map<String, String> labels2 = new HashMap<>();
-//    labels2.put("l3", "v3");
-//    labels2.put("l4", "v4");
-//    Assert.assertEquals(1000L, client.add("seriesAdd2", 1000L, 1.1, 10000, labels2));
-//    Range[] ranges2 = client.mrange(500L, 4600L, Aggregation.COUNT, 1, true, "l4=v4");
-//    Assert.assertEquals(1, ranges2.length);
-//    Assert.assertEquals(labels2, ranges2[0].getLabels());
-//
-//    Map<String, String> labels3 = new HashMap<>();
-//    labels3.put("l3", "v33");
-//    labels3.put("l4", "v4");
-//    Assert.assertEquals(1000L, client.add("seriesAdd3", 1000L, 1.1, labels3));
-//    Assert.assertEquals(2000L, client.add("seriesAdd3", 2000L, 1.1, labels3));
-//    Assert.assertEquals(3000L, client.add("seriesAdd3", 3000L, 1.1, labels3));
-//    Range[] ranges3 = client.mrange(500L, 4600L, Aggregation.AVG, 1L, true, 2, "l4=v4");
-//    Assert.assertEquals(2, ranges3.length);
-//    Assert.assertEquals(1, ranges3[0].getValues().length);
-//    Assert.assertEquals(labels2, ranges3[0].getLabels());
-//    Assert.assertEquals(2, ranges3[1].getValues().length);
-//    Assert.assertEquals(labels3, ranges3[1].getLabels());
-//
-//    if(moduleVersion>=10400) {
-//      // Back filling
-//      Assert.assertEquals(800L, client.add("seriesAdd", 800L, 1.1));
-//      Assert.assertEquals(700L, client.add("seriesAdd", 700L, 1.1, 10000));
-//      Assert.assertEquals(600L, client.add("seriesAdd", 600L, 1.1, 10000, null));
-//    }
-//
-//    // Range on none existing key
-//    try {
-//      client.range("seriesAdd1", 500L, 4000L, Aggregation.COUNT, 1);
-//      Assert.fail();
-//    } catch(JedisDataException e) {
-//    }
+    try {
+      client.mrange(500L, 4600L, Aggregation.COUNT, 1);
+      Assert.fail();
+    }catch(JedisDataException e) {}
+
+    try {
+      client.mrange(500L, 4600L, Aggregation.COUNT, 1, null);
+      Assert.fail();
+    }catch(JedisDataException e) {}
+
+    Range[] ranges = client.mrange(500L, 4600L, Aggregation.COUNT, 1, "l1=v1");
+    Assert.assertEquals(1, ranges.length);
+
+    Range range = ranges[0];
+    Assert.assertEquals("seriesAdd", range.getKey());
+    Assert.assertEquals(new HashMap<>(), range.getLabels());
+
+    Value[] rangeValues = range.getValues();
+    Assert.assertEquals(4, rangeValues.length);
+    Assert.assertEquals( new Value(1000, 1), rangeValues[0]);
+    Assert.assertNotEquals( new Value(1000, 1.1), rangeValues[0]);
+    Assert.assertEquals( 2000L, rangeValues[1].getTime());
+    Assert.assertEquals( "(2000:1.0)", rangeValues[1].toString());
+    Assert.assertEquals( 1072695248, rangeValues[1].hashCode());
+    Assert.assertNotEquals("(2000:1.0)", rangeValues[1]); // verify wrong type
+
+    // Add with labels
+    Map<String, String> labels2 = new HashMap<>();
+    labels2.put("l3", "v3");
+    labels2.put("l4", "v4");
+    Assert.assertEquals(1000L, client.add("seriesAdd2", 1000L, 1.1, 10000, labels2));
+    Range[] ranges2 = client.mrange(500L, 4600L, Aggregation.COUNT, 1, true, "l4=v4");
+    Assert.assertEquals(1, ranges2.length);
+    Assert.assertEquals(labels2, ranges2[0].getLabels());
+
+    Map<String, String> labels3 = new HashMap<>();
+    labels3.put("l3", "v33");
+    labels3.put("l4", "v4");
+    Assert.assertEquals(1000L, client.add("seriesAdd3", 1000L, 1.1, labels3));
+    Assert.assertEquals(2000L, client.add("seriesAdd3", 2000L, 1.1, labels3));
+    Assert.assertEquals(3000L, client.add("seriesAdd3", 3000L, 1.1, labels3));
+    Range[] ranges3 = client.mrange(500L, 4600L, Aggregation.AVG, 1L, true, 2, "l4=v4");
+    Assert.assertEquals(2, ranges3.length);
+    Assert.assertEquals(1, ranges3[0].getValues().length);
+    Assert.assertEquals(labels2, ranges3[0].getLabels());
+    Assert.assertEquals(2, ranges3[1].getValues().length);
+    Assert.assertEquals(labels3, ranges3[1].getLabels());
+
+    if(moduleVersion>=10400) {
+      // Back filling
+      Assert.assertEquals(800L, client.add("seriesAdd", 800L, 1.1));
+      Assert.assertEquals(700L, client.add("seriesAdd", 700L, 1.1, 10000));
+      Assert.assertEquals(600L, client.add("seriesAdd", 600L, 1.1, 10000, null));
+    }
+
+    // Range on none existing key
+    try {
+      client.range("seriesAdd1", 500L, 4000L, Aggregation.COUNT, 1);
+      Assert.fail();
+    } catch(JedisDataException e) {
+    }
   }
 
   @Test

--- a/src/test/java/com/redislabs/redistimeseries/RedisTimeSeriesTest.java
+++ b/src/test/java/com/redislabs/redistimeseries/RedisTimeSeriesTest.java
@@ -164,67 +164,67 @@ public class RedisTimeSeriesTest {
     Assert.assertEquals(1, values.length);
     Assert.assertArrayEquals(expectedOverallMaxValues, values);
 
-    try {
-      client.mrange(500L, 4600L, Aggregation.COUNT, 1);
-      Assert.fail();
-    }catch(JedisDataException e) {}
-
-    try {
-      client.mrange(500L, 4600L, Aggregation.COUNT, 1, (String[])null);
-      Assert.fail();
-    }catch(JedisDataException e) {}
-
-    Range[] ranges = client.mrange(500L, 4600L, Aggregation.COUNT, 1, "l1=v1");
-    Assert.assertEquals(1, ranges.length);
-
-    Range range = ranges[0];
-    Assert.assertEquals("seriesAdd", range.getKey());
-    Assert.assertEquals(new HashMap<>(), range.getLabels());
-
-    Value[] rangeValues = range.getValues();
-    Assert.assertEquals(4, rangeValues.length);
-    Assert.assertEquals( new Value(1000, 1), rangeValues[0]);
-    Assert.assertNotEquals( new Value(1000, 1.1), rangeValues[0]);
-    Assert.assertEquals( 2000L, rangeValues[1].getTime());
-    Assert.assertEquals( "(2000:1.0)", rangeValues[1].toString());
-    Assert.assertEquals( 1072695248, rangeValues[1].hashCode());
-    Assert.assertNotEquals("(2000:1.0)", rangeValues[1]); // verify wrong type
-
-    // Add with labels
-    Map<String, String> labels2 = new HashMap<>();
-    labels2.put("l3", "v3");
-    labels2.put("l4", "v4");
-    Assert.assertEquals(1000L, client.add("seriesAdd2", 1000L, 1.1, 10000, labels2));
-    Range[] ranges2 = client.mrange(500L, 4600L, Aggregation.COUNT, 1, true, "l4=v4");
-    Assert.assertEquals(1, ranges2.length);
-    Assert.assertEquals(labels2, ranges2[0].getLabels());
-
-    Map<String, String> labels3 = new HashMap<>();
-    labels3.put("l3", "v33");
-    labels3.put("l4", "v4");
-    Assert.assertEquals(1000L, client.add("seriesAdd3", 1000L, 1.1, labels3));
-    Assert.assertEquals(2000L, client.add("seriesAdd3", 2000L, 1.1, labels3));
-    Assert.assertEquals(3000L, client.add("seriesAdd3", 3000L, 1.1, labels3));
-    Range[] ranges3 = client.mrange(500L, 4600L, Aggregation.AVG, 1L, true, 2, "l4=v4");
-    Assert.assertEquals(2, ranges3.length);
-    Assert.assertEquals(1, ranges3[0].getValues().length);
-    Assert.assertEquals(labels2, ranges3[0].getLabels());
-    Assert.assertEquals(2, ranges3[1].getValues().length);
-    Assert.assertEquals(labels3, ranges3[1].getLabels());
-
-    if(moduleVersion>=10400) {
-      // Back filling 
-      Assert.assertEquals(800L, client.add("seriesAdd", 800L, 1.1));
-      Assert.assertEquals(700L, client.add("seriesAdd", 700L, 1.1, 10000));
-      Assert.assertEquals(600L, client.add("seriesAdd", 600L, 1.1, 10000, null));
-    }
-
-    // Range on none existing key
-    try {
-      client.range("seriesAdd1", 500L, 4000L, Aggregation.COUNT, 1);
-      Assert.fail();
-    } catch(JedisDataException e) {
-    }
+//    try {
+//      client.mrange(500L, 4600L, Aggregation.COUNT, 1);
+//      Assert.fail();
+//    }catch(JedisDataException e) {}
+//
+//    try {
+//      client.mrange(500L, 4600L, Aggregation.COUNT, 1, (String[])null);
+//      Assert.fail();
+//    }catch(JedisDataException e) {}
+//
+//    Range[] ranges = client.mrange(500L, 4600L, Aggregation.COUNT, 1, "l1=v1");
+//    Assert.assertEquals(1, ranges.length);
+//
+//    Range range = ranges[0];
+//    Assert.assertEquals("seriesAdd", range.getKey());
+//    Assert.assertEquals(new HashMap<>(), range.getLabels());
+//
+//    Value[] rangeValues = range.getValues();
+//    Assert.assertEquals(4, rangeValues.length);
+//    Assert.assertEquals( new Value(1000, 1), rangeValues[0]);
+//    Assert.assertNotEquals( new Value(1000, 1.1), rangeValues[0]);
+//    Assert.assertEquals( 2000L, rangeValues[1].getTime());
+//    Assert.assertEquals( "(2000:1.0)", rangeValues[1].toString());
+//    Assert.assertEquals( 1072695248, rangeValues[1].hashCode());
+//    Assert.assertNotEquals("(2000:1.0)", rangeValues[1]); // verify wrong type
+//
+//    // Add with labels
+//    Map<String, String> labels2 = new HashMap<>();
+//    labels2.put("l3", "v3");
+//    labels2.put("l4", "v4");
+//    Assert.assertEquals(1000L, client.add("seriesAdd2", 1000L, 1.1, 10000, labels2));
+//    Range[] ranges2 = client.mrange(500L, 4600L, Aggregation.COUNT, 1, true, "l4=v4");
+//    Assert.assertEquals(1, ranges2.length);
+//    Assert.assertEquals(labels2, ranges2[0].getLabels());
+//
+//    Map<String, String> labels3 = new HashMap<>();
+//    labels3.put("l3", "v33");
+//    labels3.put("l4", "v4");
+//    Assert.assertEquals(1000L, client.add("seriesAdd3", 1000L, 1.1, labels3));
+//    Assert.assertEquals(2000L, client.add("seriesAdd3", 2000L, 1.1, labels3));
+//    Assert.assertEquals(3000L, client.add("seriesAdd3", 3000L, 1.1, labels3));
+//    Range[] ranges3 = client.mrange(500L, 4600L, Aggregation.AVG, 1L, true, 2, "l4=v4");
+//    Assert.assertEquals(2, ranges3.length);
+//    Assert.assertEquals(1, ranges3[0].getValues().length);
+//    Assert.assertEquals(labels2, ranges3[0].getLabels());
+//    Assert.assertEquals(2, ranges3[1].getValues().length);
+//    Assert.assertEquals(labels3, ranges3[1].getLabels());
+//
+//    if(moduleVersion>=10400) {
+//      // Back filling
+//      Assert.assertEquals(800L, client.add("seriesAdd", 800L, 1.1));
+//      Assert.assertEquals(700L, client.add("seriesAdd", 700L, 1.1, 10000));
+//      Assert.assertEquals(600L, client.add("seriesAdd", 600L, 1.1, 10000, null));
+//    }
+//
+//    // Range on none existing key
+//    try {
+//      client.range("seriesAdd1", 500L, 4000L, Aggregation.COUNT, 1);
+//      Assert.fail();
+//    } catch(JedisDataException e) {
+//    }
   }
 
   @Test
@@ -251,13 +251,13 @@ public class RedisTimeSeriesTest {
 
     long startTime = System.currentTimeMillis();
     Thread.sleep(1);
-    long add1 = client.add("seriesAdd2", 0, 1.1, 10000, null);
+    long add1 = client.add("seriesAdd2",1.1, 10000 );
     Assert.assertTrue(add1>startTime);
     Thread.sleep(1);
-    long add2 = client.add("seriesAdd2", 0, 3.2, null);
+    long add2 = client.add("seriesAdd2", 3.2q);
     Assert.assertTrue(add2>add1);
     Thread.sleep(1);
-    long add3 = client.add("seriesAdd2", 0, 3.2, 10000);
+    long add3 = client.add("seriesAdd2", 3.2);
     Assert.assertTrue(add3>add2);
     Thread.sleep(1);
     long add4 = client.add("seriesAdd2", -1.2);

--- a/src/test/java/com/redislabs/redistimeseries/RedisTimeSeriesTest.java
+++ b/src/test/java/com/redislabs/redistimeseries/RedisTimeSeriesTest.java
@@ -254,7 +254,7 @@ public class RedisTimeSeriesTest {
     long add1 = client.add("seriesAdd2",1.1, 10000 );
     Assert.assertTrue(add1>startTime);
     Thread.sleep(1);
-    long add2 = client.add("seriesAdd2", 3.2q);
+    long add2 = client.add("seriesAdd2", 3.2);
     Assert.assertTrue(add2>add1);
     Thread.sleep(1);
     long add3 = client.add("seriesAdd2", 3.2);

--- a/src/test/java/com/redislabs/redistimeseries/RedisTimeSeriesTest.java
+++ b/src/test/java/com/redislabs/redistimeseries/RedisTimeSeriesTest.java
@@ -311,15 +311,20 @@ public class RedisTimeSeriesTest {
     Value[] values = client.range("seriesIncDec", 1L, 3L);
     Assert.assertEquals(3, values.length);
     Assert.assertEquals(2, values[2].getValue(), 0);
-    Assert.assertEquals(3L, client.decrBy("seriesIncDec", 2,3L), 0);
-    values = client.range("seriesIncDec", 1L, Long.MAX_VALUE);
-    Assert.assertEquals(3, values.length);
-    try {
-      client.incrBy("seriesIncDec", 3, 1L);
-      Assert.fail();
-    } catch(JedisDataException e) {
-      // Error on incrby in the past
+    if(moduleVersion>=10400) {
+      Assert.assertEquals(3L, client.decrBy("seriesIncDec", 2,3L), 0);
+      values = client.range("seriesIncDec", 1L, Long.MAX_VALUE);
+      Assert.assertEquals(3, values.length);
+    } else {
+      try {
+        client.incrBy("seriesIncDec", 3, 0L);
+        Assert.fail();
+      } catch(JedisDataException e) {
+        // Error on incrby in the past
+      }
     }
+
+
   }
 
   @Test

--- a/src/test/java/com/redislabs/redistimeseries/RedisTimeSeriesTest.java
+++ b/src/test/java/com/redislabs/redistimeseries/RedisTimeSeriesTest.java
@@ -205,7 +205,7 @@ public class RedisTimeSeriesTest {
     Assert.assertEquals(1000L, client.add("seriesAdd3", 1000L, 1.1, labels3));
     Assert.assertEquals(2000L, client.add("seriesAdd3", 2000L, 1.1, labels3));
     Assert.assertEquals(3000L, client.add("seriesAdd3", 3000L, 1.1, labels3));
-    Range[] ranges3 = client.mrange(500L, 4600L, Aggregation.AVG, 1, true, 2, "l4=v4");
+    Range[] ranges3 = client.mrange(500L, 4600L, Aggregation.AVG, 1L, true, 2, "l4=v4");
     Assert.assertEquals(2, ranges3.length);
     Assert.assertEquals(1, ranges3[0].getValues().length);
     Assert.assertEquals(labels2, ranges3[0].getLabels());
@@ -521,7 +521,7 @@ public class RedisTimeSeriesTest {
     Assert.assertEquals(2222L, client.add("seriesMRevRange1", 2222L, 3.1, 10000, labels1));
     Range[] ranges1 = client.mrevrange(500L, 4600L, Aggregation.COUNT, 1, true, "l4=v4");
     Assert.assertEquals(1, ranges1.length);
-    Assert.assertEquals(labels1, ranges1[0].getLables());
+    Assert.assertEquals(labels1, ranges1[0].getLabels());
     Assert.assertArrayEquals(new Value[]{new Value(2222L, 1.0), new Value(1000L, 1.0)}, ranges1[0].getValues());
     
     Map<String, String> labels2 = new HashMap<>();
@@ -531,9 +531,9 @@ public class RedisTimeSeriesTest {
     Assert.assertEquals(1111L, client.add("seriesMRevRange2", 1111L, 99.99, 10000, labels2));
     Range[] ranges2 = client.mrevrange(500L, 4600L, "l3=v3");
     Assert.assertEquals(2, ranges2.length);
-    Assert.assertEquals(new HashMap<String, String>(), ranges2[0].getLables());
+    Assert.assertEquals(new HashMap<String, String>(), ranges2[0].getLabels());
     Assert.assertArrayEquals(new Value[]{new Value(2222L, 3.1), new Value(1000L, 1.1)}, ranges2[0].getValues());
-    Assert.assertEquals(new HashMap<String, String>(), ranges2[0].getLables());
+    Assert.assertEquals(new HashMap<String, String>(), ranges2[0].getLabels());
     Assert.assertArrayEquals(new Value[]{new Value(1111L, 99.99), new Value(1000L, 8.88)}, ranges2[1].getValues());
     
     Map<String, String> labels3 = new HashMap<>();
@@ -544,9 +544,9 @@ public class RedisTimeSeriesTest {
     Assert.assertEquals(3300L, client.add("seriesMRevRange3", 3300L, -33, labels3));
     Range[] ranges3 = client.mrevrange(500L, 4600L, Aggregation.AVG, 500, true, 5, "l4=v4");
     Assert.assertEquals(2, ranges3.length);
-    Assert.assertEquals(labels1, ranges3[0].getLables());
+    Assert.assertEquals(labels1, ranges3[0].getLabels());
     Assert.assertArrayEquals(new Value[]{new Value(2000L, 3.1), new Value(1000L, 1.1)}, ranges3[0].getValues());
-    Assert.assertEquals(labels3, ranges3[1].getLables());
+    Assert.assertEquals(labels3, ranges3[1].getLabels());
     Assert.assertArrayEquals(new Value[]{new Value(3000L, -33.0), new Value(2000L, 0.0)}, ranges3[1].getValues());
   }
 }


### PR DESCRIPTION
This PR:
- Enables specifying the chunk size in Bytes of a time-series. Further reference: https://oss.redislabs.com/redistimeseries/master/commands/#tscreate
- Fixes #26 by relying on fixed timestamps
- Extends tests for features present on RedisTimeSeries >= v1.4
- Refactors reply parsing and common command wrapper logic